### PR TITLE
メモの結合機能

### DIFF
--- a/common.js
+++ b/common.js
@@ -618,7 +618,6 @@ handleUnsavedLog(event) {
       }; 
       if (this.dialog.showConfirmation(options) == 1) return;
       //ダウンロードページを開く
-      const shell = require('electron').shell;
       shell.openExternal(this.config.get('liteManualDownloadURL'));
     })
 
@@ -656,12 +655,14 @@ handleUnsavedLog(event) {
   }
 
   openSupportSite() {
-    const shell = require('electron').shell;
     shell.openExternal('https://do-gugan.com/tools/do-gagan3/');
   }
 
+  openShortcutManual() {
+    shell.openExternal('https://do-gugan.com/tools/do-gagan3/#shortcuts');
+  }
+
   openMarkerPage() {
-    const shell = require('electron').shell;
     shell.openExternal('https://do-gugan.com/tools/marker/');
   }
 
@@ -980,10 +981,10 @@ handleUnsavedLog(event) {
    * @param {Number} length 選択文字数（1以上の時は分割不可）
    */
    splitLog(id, selectionStart, selectionEnd) {
-    // console.log("split here");
-    // console.log("id:" + id);
-    // console.log("selectionStart:" + selectionStart);
-    // console.log("selectionEnd:" + selectionEnd);
+     console.log("split here");
+     console.log("id:" + id);
+     console.log("selectionStart:" + selectionStart);
+     console.log("selectionEnd:" + selectionEnd);
     const _ = new this.i18n(this.lang, 'dialog');
     if (selectionStart != selectionEnd) {
               //"1文字以上の文字を選択していると分割できません。",

--- a/common.js
+++ b/common.js
@@ -897,6 +897,13 @@ handleUnsavedLog(event) {
   //idで指定されたセルとその次のセルを結合
   mergeCurrentAndNextCells(id) {
     //console.log("received id:"+id);
+    if (id == undefined) {
+      //メインメニューからの実行などで対象セルが指定されていない時はレンダラーに問い合わせて取得する
+      id = this.mainWin.webContents.send('execute-merge-cells');
+      return;
+    }
+
+    //idが指定されている場合は実行継続
     const currentCell = records.find(r => r.id == id);
     const currentCellIndex = records.findIndex((element) => element == currentCell);
     //console.log("index:"+currentCellIndex+" length:"+records.length);

--- a/index.js
+++ b/index.js
@@ -250,11 +250,17 @@ app.on('window-all-closed', () => {
       console.log("macOS");
       return true;
     } else {
-      console.log("not acOS");
+      console.log("not macOS");
       return false;
     }
   });
   // #endregion
+
+  //レンダラーからメニュー項目を有効化・無効化する
+  ipcMain.on('enableOrDisableMenuItemMerge', (event, arg) => {
+    const bool = JSON.parse(arg);
+    menu.enableOrDisableMenuItemMerge(bool.key);
+  });
 
   //--------------------------------
   // #region ログ（タイムスタンプ）上のコンテクストメニューを開く

--- a/index.js
+++ b/index.js
@@ -263,6 +263,17 @@ app.on('window-all-closed', () => {
   });
 
   //--------------------------------
+  // 選択中のセルと次のセルを結合する（次のセルの中身を末尾に連結し、次のセルを削除）
+  //--------------------------------
+  ipcMain.on('mergeCurrentAndNextCells',(event, arg) => {
+    //実際の処理はレンダラー（renderer.js）側でtextareaのキーボードイベントから呼んで処理
+    const id = JSON.parse(arg);
+    //console.log("id:"+id.key);
+    common.mergeCurrentAndNextCells(id.key);
+  });
+
+
+  //--------------------------------
   // #region ログ（タイムスタンプ）上のコンテクストメニューを開く
   //--------------------------------
   ipcMain.on('openContextMenuOn', (event, id) => {

--- a/index.js
+++ b/index.js
@@ -309,7 +309,7 @@ app.on('window-all-closed', () => {
             }}
         ]
     },
-    {
+  {
         label: _.t('DELETE_ITEM'), click: ()=>{
             common.deleteRow(id);
         }
@@ -345,6 +345,11 @@ app.on('window-all-closed', () => {
       {id:'PASTE', label: _.t('PASTE'), role: 'paste'},
       {type: 'separator'},
       {
+        label: _.t('MERGE')+'(^F)', click: ()=>{
+            common.mergeCurrentAndNextCells(id);
+      }
+      },
+        {
           label: _.t('SPLIT_HERE'), click: ()=>{
               common.splitLog(id, selectionStart, selectionEnd);
           }

--- a/locales/en/menu.json
+++ b/locales/en/menu.json
@@ -24,6 +24,7 @@
   "PASTE": "Paste",
   "REPLACE": "Replace...",
   "SPLIT_HERE": "Split here",
+  "MERGE": "Merge with next Memo",
   
   "PLAYBACK-CONTROL": "Playback",
   "PLAY-PAUSE": "Play/Pause",

--- a/locales/en/menu.json
+++ b/locales/en/menu.json
@@ -55,6 +55,7 @@
   "HELP": "Help",
   "GOTO-MARKER-PAGE": "Do-gagan Marker",
   "GOTO-SUPPORT-PAGE": "Support Page",
+  "GOTO-SHORCUT-PAGE": "Keyboard Shorcuts",
   "VERSION-INFO": "Version Info.",
 
   "SPEAKERLABEL": "Speaker label",

--- a/locales/ja/menu.json
+++ b/locales/ja/menu.json
@@ -55,6 +55,7 @@
     "HELP": "ヘルプ",
     "GOTO-MARKER-PAGE": "動画眼マーカー",
     "GOTO-SUPPORT-PAGE": "サポートページ",
+    "GOTO-SHORCUT-PAGE": "キーボードショートカット一覧",
     "VERSION-INFO": "バージョン情報",
 
     "SPEAKERLABEL": "話者ラベル",

--- a/locales/ja/menu.json
+++ b/locales/ja/menu.json
@@ -24,7 +24,8 @@
     "PASTE": "貼り付け",
     "REPLACE": "置換...",
     "SPLIT_HERE": "ここで分割",
-  
+    "MERGE": "次のメモと統合",
+
     "PLAYBACK-CONTROL": "再生操作",
     "PLAY-PAUSE": "再生/一時停止",
     "JUMP_F": "前へジャンプ",

--- a/menu.js
+++ b/menu.js
@@ -83,8 +83,8 @@ const setTemplate = (lang='ja') => {
                 {id:'REPLACE', label: _.t('REPLACE'), enabled: false, click: ()=>{
                     common.openReplaceWindow();
                 }},
-                {id:'MERGE', label: _.t('MERGE'), enabled: false,accelerator: 'CmdOrCtrl+F', click: ()=>{
-                    common.margeNextCell();
+                {id:'MERGE', label: _.t('MERGE'), enabled: false,accelerator: 'Control+F', click: ()=>{
+                    //ここからは呼ばず、レンダラーのtextareaのkeyUpイベントから処理
                 }}
             ]
         },

--- a/menu.js
+++ b/menu.js
@@ -84,7 +84,8 @@ const setTemplate = (lang='ja') => {
                     common.openReplaceWindow();
                 }},
                 {id:'MERGE', label: _.t('MERGE'), enabled: false,accelerator: 'Control+F', click: ()=>{
-                    //ここからは呼ばず、レンダラーのtextareaのkeyUpイベントから処理
+                    //メインメニューから実行する場合、対象のセルがわからないので引数なしで呼び出す
+                    common.mergeCurrentAndNextCells();
                 }}
             ]
         },

--- a/menu.js
+++ b/menu.js
@@ -207,6 +207,10 @@ const setTemplate = (lang='ja') => {
                     //console.log('GOTO-SUPPORT-PAGE');
                     common.openSupportSite();
                 }},
+                {label: _.t('GOTO-SHORCUT-PAGE'), click: ()=>{
+                    //console.log('GOTO-SUPPORT-PAGE');
+                    common.openShortcutManual();
+                }},
                 {label: _.t('VERSION-INFO'), click: ()=>{
                     common.showAbout();
                 }}

--- a/menu.js
+++ b/menu.js
@@ -82,6 +82,9 @@ const setTemplate = (lang='ja') => {
                 {type: 'separator'},
                 {id:'REPLACE', label: _.t('REPLACE'), enabled: false, click: ()=>{
                     common.openReplaceWindow();
+                }},
+                {id:'MERGE', label: _.t('MERGE'), enabled: false,accelerator: 'CmdOrCtrl+F', click: ()=>{
+                    common.margeNextCell();
                 }}
             ]
         },
@@ -286,6 +289,18 @@ const setSkipTimeFromGUI = function(direction, idx) {
     Menu.getApplicationMenu().getMenuItemById(direcKey+idx).checked = true;
 }
 
+/**
+ * メニューの「次のメモと統合」の有効化と無効化（いずれかのメモがフォーカスされると有効化）
+ * @param {boolean} bool 
+ */
+const enableOrDisableMenuItemMerge = function(bool) {
+    if (typeof bool === "boolean") {
+        Menu.getApplicationMenu().getMenuItemById('MERGE').enabled = bool;
+    } else {
+        console.log("[toggleMarge] The argument passed is not bool type. :" + bool);
+    }
+}
+
 //--------------------------------
 // exports
 //--------------------------------
@@ -294,4 +309,5 @@ module.exports = {
     toggleNewMemoBlockMenu : toggleNewMemoBlockMenu,
     enableMenuWhenMediaOpened : enableMenuWhenMediaOpened,
     setSkipTimeFromGUI: setSkipTimeFromGUI,
+    enableOrDisableMenuItemMerge: enableOrDisableMenuItemMerge
 }

--- a/preload.js
+++ b/preload.js
@@ -63,6 +63,8 @@ contextBridge.exposeInMainWorld(
     //.send(ch, ...args)は非同期でメインにメッセージを送るのみ。index.js側でipcMain.on(ch,...)で受信
     //sendMessageToMain: () => ipcRenderer.send("send-message-to-main"),
     //.sendSyncなら同期だが特に利用する必要はない
+    //値はJSONに変換する必要がある。　JSON.stringgy'{key:true})
+    //受け取った側でJSON.parse(arg)する。
 
     //結果を受け取りたい場合は.invoke
     //getSomeInfoFromMain: () => ipcRenderer.invoke("getSomeInfoFromMain").then(result => result).catch(err => console.log(err)),
@@ -110,6 +112,9 @@ contextBridge.exposeInMainWorld(
     setMediaDuration : (duration) => ipcRenderer.invoke('setMediaDuration', duration),
 
     getCurrentRecordId: (position) => ipcRenderer.invoke('getCurrentRecordId', position).then(result => result),
+
+    //メニューアイテムの有効化・無効化
+    enableOrDisableMenuItemMerge: (bool) => ipcRenderer.send('enableOrDisableMenuItemMerge', JSON.stringify({key:bool})),
 
     //OSがmacOSか調べる
     isDarwin: () => ipcRenderer.invoke("isDarwin").then(result => result).catch(err => console.log(err)),

--- a/preload.js
+++ b/preload.js
@@ -43,6 +43,7 @@ contextBridge.exposeInMainWorld(
     //コンテクストメニューの選択からの処理
     setSpeakerOfRow: (callback) => ipcRenderer.on("set-speaker-of-row", (event, id, speaker)=>callback(id, speaker)),
     deleteRow: (callback) => ipcRenderer.on("delete-row", (event, id)=>callback(id)),
+    updateRow: (callback) => ipcRenderer.on("update-row", (event, id, script)=>callback(id,script)),
 
     //メニューからのスキップ秒数の変更
     setSkipTime: (callback) => ipcRenderer.on("set-skip-time", (event, direction, idx)=>callback(direction, idx)),
@@ -115,6 +116,9 @@ contextBridge.exposeInMainWorld(
 
     //メニューアイテムの有効化・無効化
     enableOrDisableMenuItemMerge: (bool) => ipcRenderer.send('enableOrDisableMenuItemMerge', JSON.stringify({key:bool})),
+
+    //メモのセルをマージする
+    mergeCurrentAndNextCells: (id) => ipcRenderer.send('mergeCurrentAndNextCells', JSON.stringify({key:id})),
 
     //OSがmacOSか調べる
     isDarwin: () => ipcRenderer.invoke("isDarwin").then(result => result).catch(err => console.log(err)),

--- a/preload.js
+++ b/preload.js
@@ -57,6 +57,9 @@ contextBridge.exposeInMainWorld(
     //touchbarのスライダー操作に連動して再生位置を更新
     changePositionFromTouchbar: (callback) => ipcRenderer.on("change-position-from-touchbar", (event, pos)=>callback(pos)),
 
+    //メニューからセル統合を実行
+    executeMergeCells: (callback) => ipcRenderer.on("execute-merge-cells", ()=>callback()),
+
     // --------------------------------------------
     //         レンダラー(HTML) → メインプロセス
     // --------------------------------------------

--- a/renderer.js
+++ b/renderer.js
@@ -281,7 +281,7 @@ function mediaOpened (path) {
 
 //メインプロセスから1件のレコードを表示
 window.api.addRecordToList((record) => {
-    const html = `<div class="row" id="${record.id}"><div class="inTime speaker${record.speaker}" onclick="timeClicked(event);" onContextmenu="openContextMenuOn(event)">${secToMinSec(record.inTime)}</div><div class="script"><textarea oninput="editTextarea(event.target);" onkeyup="keyupTextarea(event);" onContextmenu="openContextMenuOnText(event)">${record.script}</textarea></div></div>`;
+    const html = `<div class="row" id="${record.id}"><div class="inTime speaker${record.speaker}" onclick="timeClicked(event);" onContextmenu="openContextMenuOn(event)">${secToMinSec(record.inTime)}</div><div class="script"><textarea oninput="editTextarea(event.target);" onkeyup="keyupTextarea(event);" onContextmenu="openContextMenuOnText(event)" onfocus="cellFocused(event)" onblur="cellBlured(event)">${record.script}</textarea></div></div>`;
     memolist.innerHTML += html;
 
     //セルの高さを文字数にあわせて調整
@@ -293,7 +293,7 @@ window.api.addRecordToList((record) => {
 window.api.addRecordsToList((records) => {
     let html = "";
     records.forEach(r => {
-        html += `<div class="row" id="${r.id}"><div class="inTime speaker${r.speaker}" onclick="timeClicked(event);" onContextmenu="openContextMenuOn(event)">${secToMinSec(r.inTime)}</div><div class="script"><textarea oninput="editTextarea(event.target);" onkeyup="keyupTextarea(event);" onContextmenu="openContextMenuOnText(event)">${r.script}</textarea></div></div>`;
+        html += `<div class="row" id="${r.id}"><div class="inTime speaker${r.speaker}" onclick="timeClicked(event);" onContextmenu="openContextMenuOn(event)">${secToMinSec(r.inTime)}</div><div class="script"><textarea oninput="editTextarea(event.target);" onkeyup="keyupTextarea(event);" onContextmenu="openContextMenuOnText(event)" onfocus="cellFocused(event)" onblur="cellBlured(event)">${r.script}</textarea></div></div>`;
     });
     memolist.innerHTML = html;
 
@@ -737,6 +737,19 @@ function openContextMenuOnText(e) {
     window.api.openContextMenuOnText(id, e.target.selectionStart , e.target.selectionEnd);
 }
 
+//メモリスト中のセルが選択された
+function cellFocused(e) {
+    //console.log("cell focused.");
+    //メニューの「」を有効化する    
+    window.api.enableOrDisableMenuItemMerge(true);
+}
+
+//メモリスト中のセル選択が解除された
+function cellBlured(e) {
+    //console.log("cell blured.");
+    //メニューの「」を無効化する
+    window.api.enableOrDisableMenuItemMerge(false);
+}
 
 //メインプロセスからリスト上の指定ID行の話者クラスを変更
 window.api.setSpeakerOfRow((id, speaker)=>{

--- a/renderer.js
+++ b/renderer.js
@@ -703,6 +703,14 @@ function resizeTextarea(textarea) {
 }
 
 function keyupTextarea(event) {
+    //Ctrl + Fが押されたらセルマージ処理
+    if (event.key == "f" && event.ctrlKey == true) {
+        const currentCellID = event.target.parentElement.parentElement.id;
+        //console.log("MergeCell on " + currentCellID);        
+        window.api.mergeCurrentAndNextCells(currentCellID);
+    }
+
+    //Escが押されたらフォーカスを外す
     if (event.key == 'Escape') {
         event.target.blur();
     }
@@ -762,7 +770,20 @@ window.api.setSpeakerOfRow((id, speaker)=>{
 
 //メインプロセスから指定ID行を削除
 window.api.deleteRow((id)=>{
+    //console.log("deleteRow:"+id);
     document.querySelector('#'+ id).remove();
+})
+
+//メインプロセスから指定ID行のメモを更新
+window.api.updateRow((id, script)=>{
+    //console.log("updateRow:"+id+"to "+script);
+    const div = document.querySelector('#'+ id);
+    const ta = div.querySelector('textarea');
+    ta.innerText = script;
+    //カーソルを最後の文字の後ろに移動
+    ta.setSelectionRange(ta.value.length,ta.value.length);
+    //テキストエリアの高さを更新
+    resizeTextarea(ta);
 })
 
 

--- a/renderer.js
+++ b/renderer.js
@@ -745,6 +745,10 @@ function openContextMenuOnText(e) {
     window.api.openContextMenuOnText(id, e.target.selectionStart , e.target.selectionEnd);
 }
 
+//----------------------------------------------------
+// #region レコードのマージ関連
+//----------------------------------------------------
+
 //メモリスト中のセルが選択された
 function cellFocused(e) {
     //console.log("cell focused.");
@@ -758,6 +762,17 @@ function cellBlured(e) {
     //メニューの「」を無効化する
     window.api.enableOrDisableMenuItemMerge(false);
 }
+
+//メインメニューからセル結合を実行
+window.api.executeMergeCells(()=>{
+    //対象セルのIDを調べる
+    const recordId = document.activeElement.parentElement.parentElement.id;
+    console.log(recordId);
+    window.api.mergeCurrentAndNextCells(recordId);
+})
+
+
+/* #endregion */
 
 //メインプロセスからリスト上の指定ID行の話者クラスを変更
 window.api.setSpeakerOfRow((id, speaker)=>{


### PR DESCRIPTION
AI書き起こし結果が細切れになる傾向があるので、選択したメモと直後のメモを結合して1つにまとめる機能を実装。
いずれかのメモがフォーカスされた（カーソルがある）状態で、
- 編集メニューから「次のメモと結合」
- リストの任意のメモ上で右クリックして「次のメモと結合」
- Ctrl + F
で実行。
直後のメモ内容が当該メモの末尾に挿入され、直後のメモ行は削除される。

ショートカットはMergeのMが他で使用済みで、かつ連続して押しやすいことなどを考慮してFを選択。Fusion？